### PR TITLE
'true' and 'false' strings

### DIFF
--- a/lib/upcast.js
+++ b/lib/upcast.js
@@ -119,15 +119,29 @@
         return [];
     };
     cast.array.string = function (val) {
+        if (val === 'false' || val === 'true'){
+            return [cast.boolean.string(val)];
+        }
         return val.split('');
     };
     cast.boolean.array = function (val) {
         return val.length > 0;
     };
+    cast.boolean.string = function (val) {
+        if (val === 'false'){
+            return false;
+        }
+        else{
+            return cast.boolean(val);
+        }
+    };
     cast.number.array = function (val) {
         return to(to(val, 'string'), 'number');
     };
     cast.number.string = function (val) {
+        if (val === 'false' || val === 'true'){
+            val = cast.boolean.string(val);
+        }
         var num = Number(val, 10);
         return (isNaN(num) ? 0 : num);
     };
@@ -139,6 +153,12 @@
     };
     cast.string['null'] = cast.string['undefined'] = function () {
         return '';
+    };
+    cast.object.string = function (val) {
+        if (val === 'false' || val === 'true'){
+            val = cast.boolean.string(val);
+        }
+        return cast.object(val);
     };
 
 

--- a/test/unit/upcast.js
+++ b/test/unit/upcast.js
@@ -145,8 +145,15 @@
                 { from: {foo: 'bar'},    to: [{foo: 'bar'}] },
                 { from: 'foo',           to: ['f', 'o', 'o'] },
                 { from: '',              to: [] },
+                { from: 'true',          to: [true] },
+                { from: 'false',         to: [false] },
                 { from: undefined,       to: [] }
             ]);
+
+             it('should convert to arrays with correct types', function () {
+                assert.strictEqual(upcast.to('true','array')[0],true);
+                assert.strictEqual(upcast.to('false','array')[0],false);
+            });
 
             testTo('should convert to booleans correctly', 'boolean', [
                 { from: ['a', 'b', 'c'], to: true },
@@ -163,6 +170,8 @@
                 { from: {foo: 'bar'},    to: true },
                 { from: 'foo',           to: true },
                 { from: '',              to: false },
+                { from: 'true',          to: true },
+                { from: 'false',         to: false },
                 { from: undefined,       to: false }
             ]);
 
@@ -180,6 +189,8 @@
                 {foo: 'bar'},
                 'foo',
                 '',
+                'true',
+                'false',
                 undefined
             ]);
 
@@ -198,6 +209,8 @@
                 { from: {foo: 'bar'},    to: null },
                 { from: 'foo',           to: null },
                 { from: '',              to: null },
+                { from: 'true',          to: null },
+                { from: 'false',         to: null },
                 { from: undefined,       to: null }
             ]);
 
@@ -218,6 +231,8 @@
                 { from: {foo: 'bar'},    to: NaN },
                 { from: 'foo',           to: 0 },
                 { from: '',              to: 0 },
+                { from: 'true',          to: 1 },
+                { from: 'false',         to: 0 },
                 { from: undefined,       to: 0 }
             ]);
 
@@ -235,6 +250,8 @@
                 { from: {foo: 'bar'},    to: {foo: 'bar'} },
                 { from: 'foo',           to: {0: 'f', 1: 'o', 2: 'o'} },
                 { from: '',              to: Object('') },
+                { from: 'true',          to: Object(true) },
+                { from: 'false',         to: Object(false) },
                 { from: undefined,       to: {} }
             ]);
 
@@ -252,6 +269,8 @@
                 { from: {foo: 'bar'},    to: '[object Object]' },
                 { from: 'foo',           to: 'foo' },
                 { from: '',              to: '' },
+                { from: 'true',          to: 'true' },
+                { from: 'false',         to: 'false' },
                 { from: undefined,       to: '' }
             ]);
 
@@ -270,6 +289,8 @@
                 { from: {foo: 'bar'},    to: undefined },
                 { from: 'foo',           to: undefined },
                 { from: '',              to: undefined },
+                { from: 'true',          to: undefined },
+                { from: 'false',         to: undefined },
                 { from: undefined,       to: undefined }
             ]);
 


### PR DESCRIPTION
Fixes one of the annoyances when casting where 'true' becomes true, but 'false' also becomes true. The only possible downside is that a string might be cast as a boolean, but that's less of a surprise than cating 'false' to true.
